### PR TITLE
Fix Typo in type name LinqToDBConnectionOptions

### DIFF
--- a/source/articles/get-started/asp-dotnet-core/index.md
+++ b/source/articles/get-started/asp-dotnet-core/index.md
@@ -38,7 +38,7 @@ using LinqToDB.Data;
 
 public class AppDataConnection: DataConnection
 {
-    public AppDataConnection(LinqToDbConnectionOptions<AppDataConnection> options)
+    public AppDataConnection(LinqToDBConnectionOptions<AppDataConnection> options)
         :base(options)
     {
 
@@ -49,7 +49,7 @@ public class AppDataConnection: DataConnection
 > Note here our `AppDataConnection` inherits from `LinqToDB.Data.DataConnection` which is the base class for the Linq2Db connection. 
 
 > [!TIP]  
->a public constructor that accepts `LinqToDbConnectionOptions<AppDataConnection>` and passes the options on to the base constructor is required.
+>a public constructor that accepts `LinqToDBConnectionOptions<AppDataConnection>` and passes the options on to the base constructor is required.
 
 ## Add Connection String
 
@@ -98,11 +98,11 @@ public class Startup
 }
 ```
 
-> [!TIP]  
-> There's plenty of other configuration options availble, if you are familiar with LINQ To DB already, you can convert your existing application over to use the new `LinqToDbConnectionOptions` class as every configuration method is supported
+> [!TIP]
+> There's plenty of other configuration options availble, if you are familiar with LINQ To DB already, you can convert your existing application over to use the new `LinqToDBConnectionOptions` class as every configuration method is supported
 
 > [!TIP]  
-> Note, only `DataConnection` supports `LinqToDbConnectionOptions`. `DataContext` is not yet supported.
+> Note, only `DataConnection` supports `LinqToDBConnectionOptions`. `DataContext` is not yet supported.
 
 > [!TIP]  
 > Use `AddLinqToDbContext<TContext, TContextImplementation>` if you would like to resolve an interface or base class instead of the concrete class in your controllers
@@ -263,7 +263,7 @@ You'll need to update your data connection to accept the new options class too.
 ```C#
 public class AppDataConnection: DataConnection
 {
-    public AppDataConnection(LinqToDbConnectionOptions<AppDataConnection> options)
+    public AppDataConnection(LinqToDBConnectionOptions<AppDataConnection> options)
         :base(options)
     {
 
@@ -272,6 +272,6 @@ public class AppDataConnection: DataConnection
 ```
 `DataConnection` will used the options passed into the base constructor to setup the connection. 
 > [!NOTE]  
-> `DataConnection` supports `LinqToDbConnectionOptions`. However `DataContext` is not yet supported.
+> `DataConnection` supports `LinqToDBConnectionOptions`. However `DataContext` is not yet supported.
 
 


### PR DESCRIPTION
Change `LinqToDbConnectionOptions` to `LinqToDBConnectionOptions` (`b` -> `B`)