### PR TITLE
Fix F# pre-build: suppress IDE0390/IDE0391 in Release

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -15,7 +15,13 @@ dotnet tool install docfx -g
 Write-Host Restore...
 # workaround for https://github.com/dotnet/docfx/pull/8375
 # also works as workaround for https://github.com/dotnet/docfx/issues/9775
-dotnet build -c Release 'submodules/linq2db/Source/LinqToDB.FSharp/LinqToDB.FSharp.fsproj'
+# -p: flags suppress IDE0390/IDE0391 enforcement in Release config. Newer Roslyn (SDK 10.0.x+
+# on the CI windows-2025 image) enforces these as errors via TreatWarningsAsErrors=true; the
+# F# pre-build builds the consumed LinqToDB.csproj transitively across all 5 TFMs and trips
+# on a few `Method can be made synchronous` sites. Docs only needs API surface, not pristine
+# style output. Older SDKs (some local dev boxes) don't enforce — the CI hit is the canonical
+# trigger.
+dotnet build -c Release -p:RunAnalyzersDuringBuild=false -p:EnforceCodeStyleInBuild=false 'submodules/linq2db/Source/LinqToDB.FSharp/LinqToDB.FSharp.fsproj'
 
 Write-Host Build DocFX documentation...
 # docfx source/docfx.json


### PR DESCRIPTION
Suppress IDE0390/IDE0391 on the F# pre-build (line 18 of `build.ps1`) by passing `-p:RunAnalyzersDuringBuild=false -p:EnforceCodeStyleInBuild=false` to `dotnet build`.

## Why

Newer Roslyn (SDK 10.0.x+ on CI's `windows-2025` image) enforces these `Method can be made synchronous` rules as errors via `TreatWarningsAsErrors=true` in Release config. The F# pre-build builds the consumed `linq2db.csproj` transitively across all 5 TFMs and trips on a few sites. Docs only consumes the API surface, not the source's analyzer/codestyle output.

## Repro

Surfaced by the deploy CI for 6.3.0 docs (post-merge of #60, build 20462):

```
error IDE0391: Method can be made synchronous (...)/Source/LinqToDB/Async/AsyncExtensions.cs(187,4)
error IDE0390: ... EnumerableHelper.cs(23,19)
error IDE0390: ... EnumerableHelper.cs(139,18)
```

Across `net462` / `net8.0` / `net9.0` / `net10.0` / `netstandard2.0`. Local repro requires same/newer SDK — older local SDKs don't enforce.

## Notes

- Mirrors what linq2db's own CI test-all does via the `RunAnalyzersDuringBuild=false` pipeline variable.
- Doesn't affect docfx metadata extraction (custom docfx fork was bumped to `Microsoft.CodeAnalysis 5.3` in the 6.3.0 cycle, which made the source generator load cleanly + the partial method get its implementation).
- `-p:` is the only effective override path; env vars get overwritten by linq2db's `Directory.Build.props` conditional `<PropertyGroup>` reassignments under Configuration==Release.
